### PR TITLE
Documentation bug: `randy.choice` requires an array argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ be overridden.
     > randy.shuffle(["J spades", "K hearts", "10 hearts"]);
     [ "K hearts", "J spades", "10 hearts" ]
 
-    > randy.choice("heads", "tails")
+    > randy.choice(["heads", "tails"])
     "heads"
 
 ## Documentation


### PR DESCRIPTION
`randy.choice` requires an array -- it does not fall back on `arguments`. Corrected documentation to reflect this.
